### PR TITLE
zipkin-client: Use ZipkinClient as inspect iface

### DIFF
--- a/storage-clients/zipkin-client/src/main/java/cas/ibm/ubc/ca/zipkin/MessagesInspectionInterfaceFactory.groovy
+++ b/storage-clients/zipkin-client/src/main/java/cas/ibm/ubc/ca/zipkin/MessagesInspectionInterfaceFactory.groovy
@@ -6,12 +6,10 @@ import java.util.concurrent.TimeUnit
 class MessagesInspectionInterfaceFactory {
 	public static MessagesInspectionInterface create(host, String port,
 											String timeout, TimeUnit timeUnit) {
-		new ZipkinRequestor(host, Integer.parseInt(port),
-			Integer.parseInt(timeout), timeUnit)
+		new ZipkinClient(host, Integer.parseInt(port))
 	}
 
-	public static MessagesInspectionInterface create(host, int port,
-											int timeout, TimeUnit timeUnit) {
-		new ZipkinRequestor(host, port, timeout, timeUnit)
+	public static MessagesInspectionInterface create(host, int port) {
+		new ZipkinClient(host, port)
 	}
 }

--- a/storage-clients/zipkin-client/src/main/java/cas/ibm/ubc/ca/zipkin/ZipkinClient.groovy
+++ b/storage-clients/zipkin-client/src/main/java/cas/ibm/ubc/ca/zipkin/ZipkinClient.groovy
@@ -1,15 +1,20 @@
 package cas.ibm.ubc.ca.zipkin;
 
+import java.util.List
+
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
+import cas.ibm.ubc.ca.interfaces.MessagesInspectionInterface
+import cas.ibm.ubc.ca.interfaces.messages.TimeInterval
+
 import cas.ibm.ubc.ca.zipkin.pogos.Annotation
 import cas.ibm.ubc.ca.zipkin.pogos.Message
 import cas.ibm.ubc.ca.zipkin.pogos.Trace
 
-public class ZipkinClient {
+public class ZipkinClient implements MessagesInspectionInterface {
 	//http://www.vogella.com/tutorials/JavaLibrary-OkHttp/article.html
 	// http://zipkin.io/zipkin-api/#/paths/
 
@@ -19,7 +24,13 @@ public class ZipkinClient {
 		requestor = new ZipkinRequestor(host, port, 10,	TimeUnit.SECONDS)
 	}
 
-	public getMessages(serviceName, period) {
+	@Override
+	public List messages(TimeInterval timeInterval) {
+		return null;
+	}
+
+	@Override
+	public List messages(String serviceInstance, TimeInterval timeInterval) {
 		//def tracesList = requestor.getTraces(serviceName: serviceName,
 		//									 limit: 1000)
 		def tracesList = requestor.getTraces(limit: 1000)
@@ -30,7 +41,7 @@ public class ZipkinClient {
 				def clientSendAnnotation = span.annotations.find {
 					it.value == 'cs'
 				}
-				if(clientSendAnnotation?.serviceName() != serviceName)
+				if(clientSendAnnotation?.serviceName() != serviceInstance)
 					return
 
 				def message = new Message()

--- a/storage-clients/zipkin-client/src/main/java/cas/ibm/ubc/ca/zipkin/ZipkinRequestor.groovy
+++ b/storage-clients/zipkin-client/src/main/java/cas/ibm/ubc/ca/zipkin/ZipkinRequestor.groovy
@@ -1,7 +1,5 @@
 package cas.ibm.ubc.ca.zipkin
 
-import cas.ibm.ubc.ca.interfaces.MessagesInspectionInterface
-import cas.ibm.ubc.ca.interfaces.messages.TimeInterval
 import cas.ibm.ubc.ca.zipkin.pogos.Annotation
 import cas.ibm.ubc.ca.zipkin.pogos.Dependency
 import cas.ibm.ubc.ca.zipkin.pogos.Span
@@ -10,7 +8,6 @@ import cas.ibm.ubc.ca.zipkin.pogos.Trace
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import java.lang.reflect.Type
-import java.util.List
 import java.util.concurrent.TimeUnit
 
 import okhttp3.HttpUrl
@@ -20,7 +17,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
 
-class ZipkinRequestor implements MessagesInspectionInterface {
+class ZipkinRequestor {
 	static final MediaType JSON = MediaType.parse('application/json; charset=utf-8')
 
 	private final OkHttpClient httpClient
@@ -139,15 +136,5 @@ class ZipkinRequestor implements MessagesInspectionInterface {
 		def request = createRequest(url, body)
 
 		httpClient.newCall(request).execute()
-	}
-
-	@Override
-	public List messages(TimeInterval timeInterval) {
-		return null;
-	}
-
-	@Override
-	public List messages(String serviceInstance, TimeInterval timeInterval) {
-		return null;
 	}
 }

--- a/storage-clients/zipkin-client/src/test/java/cas/ibm/ubc/ca/zipkin/IntegrationTest.groovy
+++ b/storage-clients/zipkin-client/src/test/java/cas/ibm/ubc/ca/zipkin/IntegrationTest.groovy
@@ -20,8 +20,8 @@ class IntegrationTest extends GroovyTestCase {
 		serverSpan = serverSpan()
 		requestor().createSpans([clientSpan, serverSpan, anotherClientSpan()])
 
-		client = new ZipkinClient(HOST, PORT)
-		fetchedMessages = client.getMessages('orders', '1h')
+		client = MessagesInspectionInterfaceFactory.create(HOST, PORT)
+		fetchedMessages = client.messages('orders', null)
 	}
 
 	void testReturnsNonEmptyMessages() {
@@ -50,8 +50,7 @@ class IntegrationTest extends GroovyTestCase {
 	}
 
 	private requestor() {
-		MessagesInspectionInterfaceFactory.create(HOST, PORT, 10, TimeUnit.SECONDS)
-		//new ZipkinRequestor(HOST, PORT, 10, TimeUnit.SECONDS)
+		new ZipkinRequestor(HOST, PORT, 10, TimeUnit.SECONDS)
 	}
 
 	private clientSpan() {


### PR DESCRIPTION
Instead of using ZipkinRequestor, which is meant to be only a wrapper to
Zipkin HTTP API.